### PR TITLE
Bump Node.js to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
   color: 'green'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "homepage": "https://github.com/sibiraj-s/action-eslint#readme",
   "main": "lib/main.js",
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
GitHub Actions has been showing this warning for a while:

![image](https://github.com/user-attachments/assets/b7cf188d-5a5b-49fe-8200-42d4cada0424)

The pre-commit hook rebuilt dist/* artifacts and didn't result in any changes, so I hope this is enough to upgrade to v20.