### PR TITLE
Update version of Node in README and in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm ci # or yarn install
@@ -108,8 +108,8 @@ Example to Run lint on all files when `.eslintrc` changes
 
 ```yml
 steps:
-  - uses: actions/checkout@v3
-  - uses: dorny/paths-filter@v2
+  - uses: actions/checkout@v4
+  - uses: dorny/paths-filter@v3
     id: filter
     with:
       filters: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci # or yarn install
       - uses: sibiraj-s/action-eslint@v3
         with:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ steps:
   # run eslint on all files if eslintrc changes
   - name: Run eslint on changed files
     if: steps.filter.outputs.eslintrc == 'false'
-    uses: sibiraj-s/action-eslint@v2
+    uses: sibiraj-s/action-eslint@v3
     with:
       all-files: ${{ steps.filter.outputs.eslintrc == 'true' }}
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The `working-dir` option can be especially useful when the eslint installation i
 
 ```yml
 steps:
-  - uses: action@v2
+  - uses: sibiraj-s/action-eslint@v3
     with:
       working-dir: apps/website
 ```
@@ -88,7 +88,7 @@ such as when a change is made to the `.eslintrc` file, where you may want to lin
 
 ```yml
 steps:
-  - uses: action@v2
+  - uses: sibiraj-s/action-eslint@v3
     with:
       all-files: true
 ```
@@ -97,7 +97,7 @@ Note: When using this input, if the `eslint-args` has the `ignore-path` option t
 
 ```yml
 steps:
-  - uses: action@v2
+  - uses: sibiraj-s/action-eslint@v3
     with:
       all-files: true
       eslint-args: '--ignore-path=.gitignore --quiet'


### PR DESCRIPTION
Follow-up to #20 - noticed some other places referenced older versions of Node only after it got merged :D

- Example of how to use this action specified `node-version: 16` in the `actions/setup-node` step
- test.yml was using `NODE_VERSION: 18`
- Bumped 3rd-party actions' versions in both README and test.yml
  - https://github.com/dorny/paths-filter
  - https://github.com/actions/setup-node
  - https://github.com/actions/checkout