### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ steps:
   - uses: sibiraj-s/action-eslint@v3
     with:
       ignore-path: .eslintignore
-      ignore-pattern: |
+      ignore-patterns: |
         dist/
         lib/
 ```
@@ -62,7 +62,7 @@ steps:
     with:
       eslint-args: '--ignore-path=.gitignore --quiet'
       ignore-path: .eslintignore
-      ignore-pattern: |
+      ignore-patterns: |
         dist/
         lib/
 ```


### PR DESCRIPTION
Fix typo in documentation. Should be `ignore-patterns` not `ignore-pattern`